### PR TITLE
Set charset as utf-8

### DIFF
--- a/doc/wsadmin/webmaster.html
+++ b/doc/wsadmin/webmaster.html
@@ -12,10 +12,11 @@ MM_reloadPage(true);
 // -->
 </script>
 <head>
-<meta name="author" 	content="ywesee">
-<meta name="publisher" 	content="ywesee">
-<meta name="copyright" 	content="ywesee">
-<title>Ganglion Webmaster</title>
+	<meta charset="utf-8">
+	<meta name="author" 	content="ywesee">
+	<meta name="publisher" 	content="ywesee">
+	<meta name="copyright" 	content="ywesee">
+	<title>Ganglion Webmaster</title>
 </head>
 <frameset rows="100%,*">
 	<frame name="admin" src="php/admin.php" frameborder="0" scrolling="auto" onresize="MM_reloadPage">


### PR DESCRIPTION
## Why

This just adds a `meta` tag for `charset`.

## Why

This tells the browser the response as `utf-8` (related to #6)